### PR TITLE
Update log4j

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /.project
 /.settings/
 /bin/
+/.idea/
 doip-logging.log

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,20 @@
-apply plugin: 'java-library'
-apply plugin: 'maven'
-apply plugin: 'eclipse'
+plugins {
+	id "java-library"
+	id "maven-publish"
+	id "eclipse"
+}
 
 version = '1.1.7'
 
 repositories {
-	jcenter()
+	mavenCentral()
 }
 
 dependencies {
-	implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.2'
-	implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.2'
-	
-	testImplementation 'junit:junit:4.12'
+	implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.1'
+	implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.1'
+
+	testImplementation 'junit:junit:4.13.2'
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/java/doip/logging/TestLogging.java
+++ b/src/test/java/doip/logging/TestLogging.java
@@ -1,5 +1,4 @@
 package doip.logging;
-import static org.junit.Assert.*;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -7,13 +6,10 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import doip.logging.LogManager;
-import doip.logging.Logger;
-
 public class TestLogging {
-	
+
 	private static Logger logger = LogManager.getLogger(TestLogging.class);
-	
+
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
 	}


### PR DESCRIPTION
- Upgrade log4j to a non-vulnerable version (2.17)
- Upgrade gradle to a newer version that supports newer JDKs
- Switched jcenter to mavenCentral, since jcenter is sunset for march 2022

You'll likely need to publish a new version and use it in the other repositories.